### PR TITLE
Refs #4778: replaced occurances of kohanaphp.com with kohanaframework.org

### DIFF
--- a/guide/codebench/index.md
+++ b/guide/codebench/index.md
@@ -26,7 +26,7 @@ Throwing valuable benchmark data away every time I needed to optimize another re
 
 Obviously providing a visual representation of the benchmark results, via simple graphs, would make interpreting them easier. Having not to think about Internet Explorer for once, made writing CSS a whole lot more easy and fun. It resulted in some fine graphs which are fully resizable.
 
-Below are two screenshots of Codebench in action. `Valid_Color` is a class made for benchmarking different ways to validate hexadecimal HTML color values, e.g. `#FFF`. If you are interested in the story behind the actual regular expressions, take a look at [this topic in the Kohana forums](http://forum.kohanaphp.com/comments.php?DiscussionID=2192).
+Below are two screenshots of Codebench in action. `Valid_Color` is a class made for benchmarking different ways to validate hexadecimal HTML color values, e.g. `#FFF`. If you are interested in the story behind the actual regular expressions, take a look at [this topic in the Kohana forums](http://forum.kohanaframework.org/discussion/2192).
 
 ![Benchmarking several ways to validate HTML color values](codebench_screenshot1.png)
 **Benchmarking seven ways to validate HTML color values**


### PR DESCRIPTION
and fixed the link to actual discussion in the forums
